### PR TITLE
refactor: убрал скролл канваса вместо его скрывания

### DIFF
--- a/src/pages/Game/Canvas.scss
+++ b/src/pages/Game/Canvas.scss
@@ -1,5 +1,7 @@
 .canvas-container {
-  width: 100%;
-  height: 100vh;
-  overflow-y: hidden;
+  height: 100%;
+}
+
+.canvas {
+  display: block;
 }

--- a/src/pages/Game/Canvas.tsx
+++ b/src/pages/Game/Canvas.tsx
@@ -29,9 +29,11 @@ const Canvas: React.FC<ICanvasProps> = ({ draw }) => {
     };
   }, [draw]);
 
-  return <div ref={containerRef} className={'canvas-container'}>
-    <canvas ref={canvasRef} />
-  </div>;
+  return (
+    <div ref={containerRef} className='canvas-container'>
+      <canvas ref={canvasRef} className='canvas' />
+    </div>
+  );
 };
 
 export default Canvas;


### PR DESCRIPTION
Скролл у канваса появлялся из-за свойства line-height: 1.15, которое идёт от html тэга. Чтобы это убрать, задал самому канвасу display: block.
Контейнеру же задал height просто как 100%, а width: 100% у него по умолчанию (блочный элемент), поэтому убрал.