### PR TITLE
defined-65 Добавление Leaderboard API, стора

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -43,6 +43,22 @@ export interface IPassword {
   newPassword: string;
 }
 
+export interface ILeaderboardRequest {
+  ratingFieldName: string;
+  cursor: number;
+  limit: number;
+}
+
+export interface ILeaderboard {
+  score: number;
+  userId: number;
+  userName: string;
+}
+
+export interface ILeaderboardData {
+  data: ILeaderboard;
+}
+
 export const baseURL = 'https://ya-praktikum.tech/api/v2';
 
 export const instance = axios.create({
@@ -53,6 +69,10 @@ export const instance = axios.create({
   }
 });
 
+export const TEAM_NAME = 'defined';
+
+export const RATING_FIELD_NAME = 'score';
+
 export const signUp = (userData: IRegisterData) => instance.post('auth/signup', userData);
 
 export const signIn = (signInData: ILoginData) => instance.post('/auth/signin', signInData);
@@ -62,6 +82,17 @@ export const getUser = async (): Promise<IUserResponse> => {
 
   return response.data;
 };
+
+export const getLeaderboard = async (leaderboardRequest: ILeaderboardRequest): Promise<ILeaderboardData[]> => {
+  const response = await instance.post(`leaderboard/${TEAM_NAME}`, leaderboardRequest);
+
+  return response.data;
+};
+
+export const addUserToLeaderboard = (data: ILeaderboard): Promise<string> => instance.post(
+  'leaderboard',
+  { data, ratingFieldName: RATING_FIELD_NAME, teamName: TEAM_NAME }
+);
 
 export const logOut = () => instance.post('auth/logout');
 

--- a/src/client.tsx
+++ b/src/client.tsx
@@ -9,11 +9,13 @@ import { store } from './store/store';
 import { sortOverload } from './utils/sortOverload';
 import { IAsyncData } from './store/interface';
 import { IUserData } from './store/slice/userSlice';
+import { ILeaderboard } from './api/api';
 
 declare global {
   interface Window {
     __INITIAL_STATE__: {
       user: IAsyncData<IUserData>;
+      leaderboard: IAsyncData<ILeaderboard[]>;
       helper: {
         firstLoading: boolean;
       };

--- a/src/middlewares/serverRenderMiddleware.tsx
+++ b/src/middlewares/serverRenderMiddleware.tsx
@@ -7,11 +7,13 @@ import { configureStore } from '@reduxjs/toolkit';
 import App from '../App';
 import { addUserData, userReducer } from '../store/slice/userSlice';
 import { helperReducer } from '../store/reducer/helper';
+import { leaderboardReducer } from '../store/slice/leaderboardSlice';
 
 export const serverRenderMiddleware = (req: Request, res: Response) => {
   const store = configureStore({
     reducer: {
       user: userReducer,
+      leaderboard: leaderboardReducer,
       helper: helperReducer
     }
   });

--- a/src/pages/Game/components/Canvas/Canvas.tsx
+++ b/src/pages/Game/components/Canvas/Canvas.tsx
@@ -1,7 +1,10 @@
 import React, { useEffect, useRef, useState } from 'react';
 import './Canvas.scss';
 import ModalGameOver from '../ModalGameOver/ModalGameOver';
-import { isGameOver, roundWin } from '../../engine';
+import { isGameOver, roundWin, score } from '../../engine';
+import { useAppDispatch } from '../../../../hooks/useAppDispatch';
+import { addUserToLeaderboard } from '../../../../store/slice/leaderboardSlice';
+import { useAppSelector } from '../../../../hooks/useAppSelector';
 
 interface ICanvasProps {
   // eslint-disable-next-line @typescript-eslint/ban-types
@@ -9,15 +12,19 @@ interface ICanvasProps {
 }
 
 const Canvas: React.FC<ICanvasProps> = ({ draw }) => {
+  const dispatch = useAppDispatch();
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [isShowModal, setIsShowModal] = useState(false);
   const [isReset, setIsReset] = useState(false);
   const [isRoundWin, setIsRoundWin] = useState(false);
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const user = useAppSelector((state) => state.user.data!);
 
   useEffect(() => {
     setIsShowModal(isGameOver);
     setIsRoundWin(roundWin);
+    isGameOver && dispatch(addUserToLeaderboard({ score, userId: user.id, userName: user.first_name }));
   }, [isGameOver]);
 
   useEffect(() => {

--- a/src/pages/Game/engine.ts
+++ b/src/pages/Game/engine.ts
@@ -38,7 +38,6 @@ let y: number; // Координата Y мяча
 let dx: number; // Приращение координаты X мяча
 let dy: number; // Приращение координаты Y мяча
 let paddleX: number; // Координата X ракетки
-let score: number; // Очки (отображаются в верхнем углу слева)
 let lives: number; // Жизни (отображаются в верхнем углу справа)
 let brickColCount: number; // Кол-во рядов кирпичей
 let brickOffsetLeft: number; // Расстояние до левого края самого левого кирпича
@@ -59,6 +58,7 @@ export enum EStep {
 export let step = EStep.INIT;
 export let isGameOver = false;
 export let roundWin = false;
+export let score: number; // Очки (отображаются в верхнем углу слева)
 
 type TBrickStatus = 'ACTIVE' | 'DELETED';
 

--- a/src/pages/Leaderboard/components/LeaderboardTable/LeaderboardTable.tsx
+++ b/src/pages/Leaderboard/components/LeaderboardTable/LeaderboardTable.tsx
@@ -2,6 +2,10 @@ import React, {
   Fragment, useState, useEffect, FC
 } from 'react';
 import './LeaderboardTable.scss';
+import { useAppDispatch } from '../../../../hooks/useAppDispatch';
+import { getLeaderboard } from '../../../../store/slice/leaderboardSlice';
+import { useAppSelector } from '../../../../hooks/useAppSelector';
+import { ILeaderboard } from '../../../../api/api';
 
 type TNumberedLeaderboardData = {
   number: number;
@@ -9,8 +13,6 @@ type TNumberedLeaderboardData = {
   name: string;
   points: number;
 };
-
-type TLeaderboardData = Omit<TNumberedLeaderboardData, 'number'>;
 
 type TSortingField = 'name' | 'points';
 
@@ -32,11 +34,8 @@ enum SortingDirection {
 }
 
 const LeaderboardTable: FC = () => {
-  const serverData: TLeaderboardData[] = [
-    { image: 'https://tinyurl.com/bdznfmzs', name: 'Сергей', points: 1400 },
-    { image: 'https://tinyurl.com/bdznfmzs', name: 'Анастасия', points: 2100 },
-    { image: 'https://tinyurl.com/bdznfmzs', name: 'Владимир', points: 700 }
-  ];
+  const dispatch = useAppDispatch();
+  const leaderboardStoreData = useAppSelector((state) => state.leaderboard.data);
   const initialSort = {
     field: SortingField.POINTS,
     direction: SortingDirection.DESC
@@ -44,7 +43,11 @@ const LeaderboardTable: FC = () => {
   const [leaderboardData, setLeaderboardData] = useState<TNumberedLeaderboardData[]>([]);
   const [sort, setSort] = useState<TSortingRules>(initialSort);
 
-  useEffect(() => setLeaderboardData(prepareData(serverData)), []);
+  useEffect(() => { dispatch(getLeaderboard()); }, []);
+
+  useEffect(() => {
+    setLeaderboardData(prepareData(leaderboardStoreData));
+  }, [leaderboardStoreData]);
 
   const handleSortButtonClick = (field: TSortingField): void => {
     let direction: TSortingDirection;
@@ -93,8 +96,9 @@ const LeaderboardTable: FC = () => {
   );
 };
 
-function prepareData(serverData: TLeaderboardData[]): TNumberedLeaderboardData[] {
-  return [...serverData]
+function prepareData(data: ILeaderboard[]): TNumberedLeaderboardData[] {
+  return data
+    .map((item) => ({ points: item.score, name: item.userName, image: 'https://tinyurl.com/bdznfmzs' }))
     .sort((a, b) => b.points - a.points)
     .map((row, i) => ({ ...row, number: i + 1 }));
 }

--- a/src/store/slice/leaderboardSlice.ts
+++ b/src/store/slice/leaderboardSlice.ts
@@ -1,0 +1,93 @@
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import {
+  getLeaderboard as getLeaderboardApi,
+  addUserToLeaderboard as addUserToLeaderboardApi,
+  ILeaderboard, RATING_FIELD_NAME, TEAM_NAME
+} from '../../api/api';
+import { EStatus, IAsyncData } from '../interface';
+import { isServer } from '../../utils/isServer';
+
+let initialState: IAsyncData<ILeaderboard[]>;
+
+if (isServer) {
+  initialState = {
+    data: [],
+    error: null,
+    status: EStatus.IDLE
+  };
+} else {
+  // eslint-disable-next-line no-underscore-dangle
+  initialState = window.__INITIAL_STATE__.leaderboard;
+}
+
+export const getLeaderboard = createAsyncThunk<ILeaderboard[], void, { rejectValue: string; }>(
+  `leaderboard/${TEAM_NAME}`,
+  async (_, { rejectWithValue }) => {
+    try {
+      const response = await getLeaderboardApi({ ratingFieldName: RATING_FIELD_NAME, cursor: 0, limit: 10 });
+
+      return response.map((item) => ({
+        score: item.data.score,
+        userId: item.data.userId,
+        userName: item.data.userName
+      }));
+    } catch (err) {
+      const errMessage = (err as Error)?.message;
+
+      return rejectWithValue(errMessage);
+    }
+  }
+);
+
+export const addUserToLeaderboard = createAsyncThunk<string, ILeaderboard, { rejectValue: string; }>(
+  'leaderboard',
+  async (leaderData: ILeaderboard, { rejectWithValue }) => {
+    try {
+      return await addUserToLeaderboardApi(leaderData);
+    } catch (err) {
+      const errMessage = (err as Error)?.message;
+
+      return rejectWithValue(errMessage);
+    }
+  }
+);
+
+export const leaderboardSlice = createSlice({
+  name: 'leaderboard',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(getLeaderboard.pending, (state) => {
+      state.status = EStatus.PENDING;
+      state.error = null;
+    });
+    builder.addCase(getLeaderboard.fulfilled, (state, { payload }) => {
+      state.data = payload;
+      state.status = EStatus.FULFILLED;
+    });
+    builder.addCase(getLeaderboard.rejected, (state, { payload }) => {
+      state.error = payload || 'Неопознанная ошибка!';
+      state.status = EStatus.REJECTED;
+    });
+
+    builder.addCase(addUserToLeaderboard.pending, (state) => {
+      state.status = EStatus.PENDING;
+      state.error = null;
+    });
+    builder.addCase(addUserToLeaderboard.fulfilled, (state) => {
+      state.status = EStatus.FULFILLED;
+    });
+    builder.addCase(addUserToLeaderboard.rejected, (state, { payload }) => {
+      state.error = payload || 'Неопознанная ошибка!';
+      state.status = EStatus.REJECTED;
+    });
+  }
+});
+
+const {
+  reducer
+} = leaderboardSlice;
+
+export {
+  reducer as leaderboardReducer
+};

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,10 +1,12 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { userReducer } from './slice/userSlice';
 import { helperReducer } from './reducer/helper';
+import { leaderboardReducer } from './slice/leaderboardSlice';
 
 export const store = configureStore({
   reducer: {
     user: userReducer,
+    leaderboard: leaderboardReducer,
     helper: helperReducer
   }
 });


### PR DESCRIPTION
Добавлено апи /leaderboard
- запрос на добавление юзера (по окончанию игры)
- запрос на подгрузку таблицы лидеров (в юзэффекте при открытии страницы)

Замечена особенность апи: попасть в таблицу рейтинга под тем же именем дважды нельзя (как в Херосах 3 например). Если кол-во очков (score) больше предыдущего набранного этим же юзером- то запись обновляется, иначе - нет.