### PR TITLE
defined-90 доработка проекта, чтобы приложение запускалось в контейнере

### DIFF
--- a/Docker-compose.yaml
+++ b/Docker-compose.yaml
@@ -6,23 +6,18 @@ services:
       context: .
     depends_on:
       - postgres
-    environment:
-      DATABASE_URL: postgres://postgres:newPassword@postgres:5432/arkanoid-db
-      NODE_ENV: development
-      PORT: 5000
     ports:
-      - "5000:5000"
+      - "8080:8080"
     restart: always
     networks:
       - awesome
+
   postgres:
-    container_name: postgres-v12 # Можно и не указывать, тогда будет взято за основу название сервиса: `postgres`
     image: postgres:12
     ports:
-      - "5678:5432"
+      - "5432:5432"
     volumes:
       - ./postgresdata:/var/lib/postgresql/data
-      - ./src/migrations/dbinit.sql:/docker-entrypoint-initdb.d/dbinit.sql
     restart: always
     environment:
       POSTGRES_USER: postgres
@@ -30,8 +25,8 @@ services:
       POSTGRES_DB: arkanoid-db
     networks:
       - awesome
+
   pgadmin:
-    container_name: pgadmin
     image: dpage/pgadmin4:6.10
     restart: always
     environment:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,9 @@
-FROM node:16
+FROM node:16.13.2
 
 WORKDIR /app
 
-COPY package.json ./
-RUN npm install
-COPY . /app
-RUN npm run build
+COPY . .
+RUN npm install && npm run build
 
-EXPOSE 5000
+EXPOSE 8080
 CMD node dist/server.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "dotenv": "16.0.1",
         "express": "4.18.1",
         "framer-motion": "6.3.3",
+        "helmet": "5.1.0",
         "pg": "8.7.3",
         "react": "18.1.0",
         "react-dom": "18.1.0",
@@ -7871,6 +7872,14 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-5.1.0.tgz",
+      "integrity": "sha512-klsunXs8rgNSZoaUrNeuCiWUxyc+wzucnEnFejUg3/A+CaF589k9qepLZZ1Jehnzig7YbD4hEuscGXuBY3fq+g==",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/hey-listen": {
@@ -21904,6 +21913,11 @@
       "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
       "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
       "dev": true
+    },
+    "helmet": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-5.1.0.tgz",
+      "integrity": "sha512-klsunXs8rgNSZoaUrNeuCiWUxyc+wzucnEnFejUg3/A+CaF589k9qepLZZ1Jehnzig7YbD4hEuscGXuBY3fq+g=="
     },
     "hey-listen": {
       "version": "1.0.8",

--- a/src/db/config.ts
+++ b/src/db/config.ts
@@ -3,8 +3,8 @@ import { topicModel } from './models/topic';
 import { messageModel } from './models/message';
 
 const sequelizeOptions: SequelizeOptions = {
-  host: 'localhost',
-  port: 5678,
+  host: 'postgres',
+  port: 5432,
   username: 'postgres',
   password: 'newPassword',
   database: 'arkanoid-db',

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,7 +11,7 @@ import { authMiddleware } from './middlewares/authMiddleware';
 import { logG } from './utils/log';
 import { getTopics } from './utils/getTopics';
 import { getMessages } from './utils/getMessages';
-import { createMessage, createTopic } from './db/init';
+import { createMessage, createTopic, initDb } from './db/init';
 import { serverRoutes } from './utils/constants/routes';
 import { getCurrentUserTheme } from './utils/getCurrentUserTheme';
 import { theme } from './utils/constants/cookieKeys';
@@ -97,6 +97,8 @@ app.get('/*', authMiddleware, serverRenderMiddleware);
 const server = https.createServer({ key, cert }, app);
 
 const port = process.env.PORT || 8080;
+
+initDb();
 
 server.listen(port, () => {
   logG(`Application is started on localhost: ${port}`);


### PR DESCRIPTION
1) В Docker-compose.yaml: убрал неиспользуемые переменные окружения; настроил порты; сервисы разделил пробелами для читаемости.
2) В Dockerfile конструкцию вида COPY-RUN-COPY-RUN привёл просто к COPY-RUN, объединив операции; версию ноды указал точно такую же, как у нас в .nvmrc указана, чтобы было соответствие.
3) В config.ts актуализировал host и port
4) Запуск базы вынес в стартовый файл приложения - server.ts. Раньше он (запуск базы) срабатывал на каждый запрос, сейчас запускается один раз.

В итоге после docker-compose up приложение доступно как обычно на https://local.ya-praktikum.tech:8080. Для деплоя, конечно, понадобятся и дальнейшие модификации, на данный момент важно, что всё поднимается в контейнерах.